### PR TITLE
Add Java 8 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    id("org.javamodularity.moduleplugin") version "1.8.12"
     id("org.openjfx.javafxplugin") version "0.0.13"
     `java-library`
     jacoco
@@ -22,6 +23,7 @@ modularity {
 }
 
 tasks.getByName<Jar>("sourcesJar") {
+    // When the mixedJavaRelease is set, the module-info.class will be packaged into the sourcesJar
     exclude("module-info.class")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,9 +17,24 @@ java {
     withSourcesJar()
 }
 
+modularity {
+    mixedJavaRelease(8)
+}
+
+tasks.getByName<Jar>("sourcesJar") {
+    exclude("module-info.class")
+}
+
+tasks.compileTestJava {
+    extensions.configure<org.javamodularity.moduleplugin.extensions.CompileTestModuleOptions> {
+        isCompileOnClasspath = true
+    }
+}
+
 javafx {
     version = "11"
     modules = listOf("javafx.base", "javafx.graphics")
+    configuration = "compileOnly"
 }
 
 repositories {
@@ -33,6 +48,10 @@ dependencies {
     compileOnlyApi("org.jetbrains:annotations:23.0.0")
     testImplementation("junit:junit:4.13.2")
     checkstyleConfig("org.hildan.checkstyle:checkstyle-config:2.5.0")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get())
 }
 
 checkstyle {


### PR DESCRIPTION
By setting the `mixedJavaRelease`, we can easily provide `module-info.class` while supporting Java 8.

Many users are still using Java 8. We have a popular JavaFX application that has to remain compatible with Java 8, and it depends on fx-gson. Providing support for Java 8 allows us to upgrade fx gson from 3. x to 4. x, so we hope you can merge this PR.