### PR TITLE
Optional depends on javafx.graphics

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -3,8 +3,8 @@
  */
 module org.hildan.fxgson {
     requires transitive com.google.gson;
-    requires transitive javafx.base; // for Property classes
-    requires transitive javafx.graphics; // for Color and Font classes
+    requires javafx.base; // for Property classes
+    requires static javafx.graphics; // for Color and Font classes
     requires static org.jetbrains.annotations;
 
     exports org.hildan.fxgson;


### PR DESCRIPTION
In fact, the dependence of FX Gson on javafx.graphics is optional. 

Although it is rare to use java.base without depends on javafx.graphics, I think it is a good thing to reduce the mandatory dependency on other modules as much as possible in module-info.java.