### PR TITLE
Exclude runtime dependencies on JavaFX

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ java {
 javafx {
     version = "11"
     modules = listOf("javafx.base", "javafx.graphics")
+    configuration = "compileOnly"
 }
 
 repositories {
@@ -33,6 +34,10 @@ dependencies {
     compileOnlyApi("org.jetbrains:annotations:23.0.0")
     testImplementation("junit:junit:4.13.2")
     checkstyleConfig("org.hildan.checkstyle:checkstyle-config:2.5.0")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get())
 }
 
 checkstyle {


### PR DESCRIPTION
I want to maintain a fork for Java 8 support, so I closed #28. But that PR contains some other useful things.

Now FX Gson incorrectly declares `org.openjfx:javafx-base:11:linux` and `org.openjfx:javafx-graphics:11:linux` as runtime dependencies in POM. This has brought troubles to users such as Windows, macOS, Linux ARM, and JDK bundled with JavaFX, it should be excluded from runtime dependencies.